### PR TITLE
Remove inline styling for label width

### DIFF
--- a/components/FloatLabel.vue
+++ b/components/FloatLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="vfl-has-label">
-    <label class="vfl-label" :class="classObject" :style="{ width }" :for="inputId">
+    <label class="vfl-label" :class="classObject" :for="inputId">
       {{ floatLabel }}
     </label>
     <slot></slot>
@@ -87,9 +87,6 @@ export default {
     formElType () {
       return this.formEl ? this.formEl.tagName.toLowerCase() : ''
     },
-    width () {
-      return this.formEl ? `${this.formEl.clientWidth}px` : 'auto'
-    },
     floatLabel () {
       if (this.label) return this.label
 
@@ -116,6 +113,7 @@ export default {
   position: absolute;
   top: 0;
   left: 0.1em;
+  right: 0;
   overflow: hidden;
   font-family: sans-serif;
   font-size: 0.8em;


### PR DESCRIPTION
The inline style that sets the width on the label element can cause problems when resizing the viewport after the component loads.  I'd prefer to use "right: 0" on the .vfl-label class, which will allow the width of the label to change as the container width changes.

~ Removed
- Inline style for label width

~ Added
- right:0 property to .vfl-label class