### PR TITLE
Adding "always" prop, so label stays always on when required

### DIFF
--- a/components/FloatLabel.vue
+++ b/components/FloatLabel.vue
@@ -15,6 +15,10 @@ export default {
       type: Boolean,
       default: true
     },
+    always: {
+      type: Boolean,
+      default: false
+    },
     label: {
       type: String,
       default: ''
@@ -80,7 +84,7 @@ export default {
     },
     classObject () {
       return {
-        'vfl-label-on-input': this.on && this.isActive,
+        'vfl-label-on-input': this.on && (this.isActive || this.always),
         'vfl-label-on-focus': this.isFocused
       }
     },


### PR DESCRIPTION
Adding the **always** prop, so label stays always on when required.

I've seen it useful with dropdowns.

Usage example:
```html
<float-label label="Current provider" always>
	<select v-model="data.obj">
		<option v-for="item in arr" :value="item.value">{{item.name}}</option>
	</select>
</float-label>
```